### PR TITLE
fix get stats/summary issue in azure/release-1.8

### DIFF
--- a/pkg/kubelet/winstats/winstats.go
+++ b/pkg/kubelet/winstats/winstats.go
@@ -139,24 +139,6 @@ func (c *Client) WinContainerInfos() (map[string]cadvisorapiv2.ContainerInfo, er
 	// root (node) container
 	infos["/"] = *c.createRootContainerInfo()
 
-	containers, err := c.dockerClient.ContainerList(context.Background(), dockertypes.ContainerListOptions{})
-
-	if err != nil {
-		return nil, err
-	}
-
-	for idx := range containers {
-		container := &containers[idx]
-
-		containerInfo, err := c.createContainerInfo(container)
-
-		if err != nil {
-			return nil, err
-		}
-
-		infos[container.ID] = *containerInfo
-	}
-
 	return infos, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
fix get stats/summary issue in azure/release-1.8
Without this PR:
```
azureuser@k8s-master-77890142-0:~$ curl http://77890k8s9010:10255/stats/summary
Internal Error: failed to get root cgroup stats: failed to get cgroup stats for "/": unexpected number of containers: 2
```

**With** this PR:
```
azureuser@k8s-master-77890142-0:~$ curl http://77890k8s9010:10255/stats/summary
{
  "node": {
   "nodeName": "77890k8s9010",
   "startTime": "2017-12-28T09:02:11Z",
   "cpu": {
    "time": "2017-12-28T09:02:18Z",
    "usageCoreNanoSeconds": 2122843740
   },
   "memory": {
    "time": "2017-12-28T09:02:18Z",
    "availableBytes": 6856040448,
    "usageBytes": 1648594944,
    "workingSetBytes": 660152320,
    "rssBytes": 0,
    "pageFaults": 0,
    "majorPageFaults": 0
   },
   "fs": {
    "time": "2017-12-28T09:02:18Z",
    "availableBytes": 0,
    "capacityBytes": 0,
    "usedBytes": 0
   },
   "runtime": {
    "imageFs": {
     "time": "2017-12-28T09:02:18Z",
     "usedBytes": 0,
     "inodesUsed": 0
    }
   }
  },
  "pods": []
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The winstats code in [azure/release-1.8](https://github.com/Azure/kubernetes/blob/release-1.8/pkg/kubelet/winstats/) is a little different from code in [k8s upstream](https://github.com/kubernetes/kubernetes/tree/master/pkg/kubelet/winstats), seems it's not an identical porting. @bobbypage 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
